### PR TITLE
Remove `conrod_rendy` `image` dep in favour of the example

### DIFF
--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -21,4 +21,5 @@ profiler = ["rendy/profiler"]
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
+conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3.0"

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.68" }
-image = "0.21"
 lazy_static = "1.4.0"
 rendy = { version = "0.5.1", default-features = false, features = ["base", "init-winit", "texture-image"] }
 
@@ -23,3 +22,4 @@ profiler = ["rendy/profiler"]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
 conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3.0"
+image = "0.21"

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.68" }
 lazy_static = "1.4.0"
-rendy = { version = "0.5.1", default-features = false, features = ["base", "init-winit", "texture-image"] }
+rendy = { version = "0.5.1", default-features = false, features = ["base", "texture"] }
 
 [features]
 empty = ["rendy/empty"]
@@ -15,6 +15,7 @@ dx12 = ["rendy/dx12"]
 gl = ["rendy/gl"]
 metal = ["rendy/metal"]
 vulkan = ["rendy/vulkan"]
+init-winit = ["rendy/init-winit"]
 no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 profiler = ["rendy/profiler"]
 
@@ -22,4 +23,8 @@ profiler = ["rendy/profiler"]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
 conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3.0"
-image = "0.21"
+image = "0.22"
+
+[[example]]
+name = "all_winit_rendy"
+required-features = ["init-winit"]

--- a/backends/conrod_rendy/examples/all_winit_rendy.rs
+++ b/backends/conrod_rendy/examples/all_winit_rendy.rs
@@ -1,7 +1,8 @@
 use conrod_example_shared::{WIN_H, WIN_W};
 use conrod_rendy::{UiTexture, UiPipeline, SimpleUiAux};
+use image;
 use rendy::{
-    command::{Families, QueueType},
+    command::{Families, QueueId, QueueType},
     factory::{self, Factory},
     graph::{
         present::PresentNode,
@@ -24,6 +25,7 @@ use rendy::{
     },
     wsi::Surface,
 };
+use std::path::Path;
 
 const CLEAR_COLOR: [f32; 4] = [0.2, 0.2, 0.2, 1.0];
 
@@ -80,7 +82,7 @@ fn main() {
                 .expect("no queue to load image");
             let family = families.family(family_id);
             let queue_id = family.queue(0).id();
-            let image = UiTexture::from_path(&logo_path, &mut factory, queue_id).unwrap();
+            let image = ui_texture_from_path(&logo_path, &mut factory, queue_id).unwrap();
             let mut image_map = conrod_core::image::Map::new();
             let rust_logo = image_map.insert(image);
             let app = conrod_example_shared::DemoApp::new(rust_logo);
@@ -202,4 +204,20 @@ where
     }
     let surface = factory.create_surface(window).expect("failed to create surface");
     *graph = Some(create_graph(win_size, factory, families, surface, aux));
+}
+
+fn ui_texture_from_path<B>(
+    path: &Path,
+    factory: &mut Factory<B>,
+    queue_id: QueueId,
+) -> Result<UiTexture<B>, image::ImageError>
+where
+    B: Backend,
+{
+    let image = image::open(path)?.to_rgba();
+    let (width, height) = image.dimensions();
+    let dimensions = [width, height];
+    let texture = UiTexture::from_rgba_bytes(&image, dimensions, factory, queue_id)
+        .expect("failed to create `UiTexture`");
+    Ok(texture)
 }

--- a/backends/conrod_rendy/src/lib.rs
+++ b/backends/conrod_rendy/src/lib.rs
@@ -1,5 +1,3 @@
-pub mod winit_convert;
-
 use conrod_core::image::{Id as ImageId, Map as ImageMap};
 use image;
 use conrod_core::mesh::{self, Mesh};

--- a/backends/conrod_winit/src/lib.rs
+++ b/backends/conrod_winit/src/lib.rs
@@ -1,6 +1,7 @@
 //! A function for converting a `winit::Event` to a `conrod::event::Input`.
 
 pub mod macros;
+pub mod v020;
 
 /// Types that have access to a `winit::Window` and can provide the necessary dimensions and hidpi
 /// factor for converting `winit::Event`s to `conrod::event::Input`, as well as set the mouse

--- a/backends/conrod_winit/src/v020.rs
+++ b/backends/conrod_winit/src/v020.rs
@@ -1,6 +1,5 @@
-use rendy::init::winit;
-
-macro_rules! convert_key {
+#[macro_export]
+macro_rules! v020_convert_key {
     ($keycode:expr) => {{
         match $keycode {
             winit::event::VirtualKeyCode::Key0 => conrod_core::input::keyboard::Key::D0,
@@ -132,7 +131,8 @@ macro_rules! convert_key {
 /// output.
 ///
 /// Requires that both the `conrod_core` and `winit` crates are in the crate root.
-macro_rules! convert_mouse_button {
+#[macro_export]
+macro_rules! v020_convert_mouse_button {
     ($mouse_button:expr) => {{
         match $mouse_button {
             winit::event::MouseButton::Left => conrod_core::input::MouseButton::Left,
@@ -152,7 +152,8 @@ macro_rules! convert_mouse_button {
 ///
 /// Expects a `winit::WindowEvent` and a reference to a window implementing `WinitWindow`.
 /// Returns an `Option<conrod_core::event::Input>`.
-macro_rules! convert_window_event {
+#[macro_export]
+macro_rules! v020_convert_window_event {
     ($event:expr, $window:expr) => {{
         // The window size in points.
         let (win_w, win_h): (f64, f64) = $window.inner_size().into();
@@ -162,8 +163,8 @@ macro_rules! convert_window_event {
         let ty = |y: conrod_core::Scalar| -(y - win_h / 2.0);
 
         // Functions for converting keys and mouse buttons.
-        let map_key = |key| convert_key!(key);
-        let map_mouse = |button| convert_mouse_button!(button);
+        let map_key = |key| $crate::v020_convert_key!(key);
+        let map_mouse = |button| $crate::v020_convert_mouse_button!(button);
 
         match $event {
             winit::event::WindowEvent::Resized(winit::dpi::LogicalSize { width, height }) => {
@@ -258,10 +259,11 @@ macro_rules! convert_window_event {
 ///
 /// Invocations of this macro require that a version of the `winit` and `conrod_core` crates are
 /// available in the crate root.
-macro_rules! convert_event {
+#[macro_export]
+macro_rules! v020_convert_event {
     ($event:expr, $window:expr) => {{
         match $event {
-            winit::event::Event::WindowEvent { event, .. } => convert_window_event!(event, $window),
+            winit::event::Event::WindowEvent { event, .. } => $crate::v020_convert_window_event!(event, $window),
             _ => None,
         }
     }};
@@ -272,7 +274,8 @@ macro_rules! convert_event {
 /// Expects a `conrod_core::cursor::MouseCursor`, returns a `winit::MouseCursor`.
 ///
 /// Requires that both the `conrod_core` and `winit` crates are in the crate root.
-macro_rules! convert_mouse_cursor {
+#[macro_export]
+macro_rules! v020_convert_mouse_cursor {
     ($cursor:expr) => {{
         match $cursor {
             conrod_core::cursor::MouseCursor::Text => winit::window::CursorIcon::Text,
@@ -297,41 +300,46 @@ macro_rules! convert_mouse_cursor {
     }};
 }
 
-/// Generate a set of conversion functions for converting between types of the crate's versions of
-/// `winit` and `conrod_core`.
-/// Maps winit's key to a conrod `Key`.
-///
-/// Expects a `winit::VirtualKeyCode` as input and returns a `conrod_core::input::keyboard::Key`.
-///
-/// Requires that both the `winit` and `conrod_core` crates exist within the crate root.
-pub fn convert_key(keycode: winit::event::VirtualKeyCode) -> conrod_core::input::keyboard::Key {
-    convert_key!(keycode)
-}
+#[macro_export]
+macro_rules! v020_conversion_fns {
+    () => {
+        /// Generate a set of conversion functions for converting between types of the crate's versions of
+        /// `winit` and `conrod_core`.
+        /// Maps winit's key to a conrod `Key`.
+        ///
+        /// Expects a `winit::VirtualKeyCode` as input and returns a `conrod_core::input::keyboard::Key`.
+        ///
+        /// Requires that both the `winit` and `conrod_core` crates exist within the crate root.
+        pub fn convert_key(keycode: winit::event::VirtualKeyCode) -> conrod_core::input::keyboard::Key {
+            $crate::v020_convert_key!(keycode)
+        }
 
-/// Convert a `winit::MouseButton` to a `conrod_core::input::MouseButton`.
-pub fn convert_mouse_button(
-    mouse_button: winit::event::MouseButton,
-) -> conrod_core::input::MouseButton {
-    convert_mouse_button!(mouse_button)
-}
+        /// Convert a `winit::MouseButton` to a `conrod_core::input::MouseButton`.
+        pub fn convert_mouse_button(
+            mouse_button: winit::event::MouseButton,
+        ) -> conrod_core::input::MouseButton {
+            $crate::v020_convert_mouse_button!(mouse_button)
+        }
 
-/// Convert a given conrod mouse cursor to the corresponding winit cursor type.
-pub fn convert_mouse_cursor(cursor: conrod_core::cursor::MouseCursor) -> winit::window::CursorIcon {
-    convert_mouse_cursor!(cursor)
-}
+        /// Convert a given conrod mouse cursor to the corresponding winit cursor type.
+        pub fn convert_mouse_cursor(cursor: conrod_core::cursor::MouseCursor) -> winit::window::CursorIcon {
+            $crate::v020_convert_mouse_cursor!(cursor)
+        }
 
-/// A function for converting a `winit::WindowEvent` to a `conrod_core::event::Input`.
-pub fn convert_window_event(
-    event: winit::event::WindowEvent,
-    window: &winit::window::Window,
-) -> Option<conrod_core::event::Input> {
-    convert_window_event!(event, window)
-}
+        /// A function for converting a `winit::WindowEvent` to a `conrod_core::event::Input`.
+        pub fn convert_window_event(
+            event: winit::event::WindowEvent,
+            window: &winit::window::Window,
+        ) -> Option<conrod_core::event::Input> {
+            $crate::v020_convert_window_event!(event, window)
+        }
 
-/// A function for converting a `winit::Event` to a `conrod_core::event::Input`.
-pub fn convert_event(
-    event: winit::event::Event<()>,
-    window: &winit::window::Window,
-) -> Option<conrod_core::event::Input> {
-    convert_event!(event, window)
+        /// A function for converting a `winit::Event` to a `conrod_core::event::Input`.
+        pub fn convert_event(
+            event: winit::event::Event<()>,
+            window: &winit::window::Window,
+        ) -> Option<conrod_core::event::Input> {
+            $crate::v020_convert_event!(event, window)
+        }
+    };
 }


### PR DESCRIPTION
This allows us to remove an unnecessary dep from `conrod_rendy` in the
case that users use no images or source their image data from some other
method.

The `UiTexture::from_path` constructor has been removed in favour of
`UiTexture::from_rgba_bytes` which allows for a similarly convenient
API. A `ui_texture_from_path` function has been added to the example to
demonstrate how to achieve the original behaviour.

This branch is based on #10.